### PR TITLE
Render discogs markup

### DIFF
--- a/app/app/templates/now-playing.html
+++ b/app/app/templates/now-playing.html
@@ -18,7 +18,7 @@
                             <a href="{{ artist.uri }}" target="_blank">{{ artist.name }}</a>
                         </h5>
                         {% if artist.profile %}
-                            <p class="card-text">{{ artist.profile|truncate }}</p>
+                            <p class="card-text">{{ artist.profile_html|truncate|safe }}</p>
                         {% endif %}
                     </div>
                 </div>

--- a/app/lib/discogs.py
+++ b/app/lib/discogs.py
@@ -1,20 +1,28 @@
 import os
 
-import discogs_client
+import requests
 
-
-discogs_client = discogs_client.Client(
-    'MidnightAthleticsRadio/0.0.1',
-    user_token=os.environ['DISCOGS_API_TOKEN']
-)
+BASE_URL = 'https://api.discogs.com'
+HEADERS = {
+    'Accept': 'application/vnd.discogs.v2.html+json',
+    'User-Agent': 'MidnightAthleticsRadio/0.0.1',
+    'Authorization': 'Discogs token={}'.format(
+        os.environ['DISCOGS_API_TOKEN']
+    ),
+}
 
 
 def get_artist_data(artist_id):
     """Returns Discogs artist data for the given artist id."""
     data = []
-    artist = discogs_client.artist(artist_id)
-    if not artist:
-        return
-    for artist in [artist] + artist.members:
-        data.append(artist.data)
+    url = '{}/artists/{}'.format(BASE_URL, str(artist_id))
+    response = requests.get(url, headers=HEADERS)
+    response.raise_for_status()
+    artist_data = response.json()
+    data.append(artist_data)
+    for member in artist_data.get('members', []):
+        response = requests.get(url, headers=HEADERS)
+        response.raise_for_status()
+        artist_data = response.json()
+        data.append(artist_data)
     return data


### PR DESCRIPTION
This commit swaps `discogs_client` out for `requests` and passes along
an accept header denoting we want rendered discogs markup in our
responses. This means that the following string:

> ... one of the founders of [l=Apollonia].

Becomes:

> ... one of the founders of <a href="...">Apollonia</a>.